### PR TITLE
Fix missing semicolon on getResultsPy snippet

### DIFF
--- a/src/snippets.ts
+++ b/src/snippets.ts
@@ -282,7 +282,7 @@ SNIPPETS.set("getResultsPy", {
 def get_results(queryset, fields, size):
     count = queryset.count()
     results = []
-    for record in queryset.values(*fields)[:size]
+    for record in queryset.values(*fields)[:size]:
         results.append(record)
     return {"count": count, "results": results}
      `.trim(),


### PR DESCRIPTION
When run in the Python REPL, the original code snippet produced an error because a semicolon was omitted 

```
  File "<python-input-1>", line 4
    for record in queryset.values(*fields)[:size]
                                                 ^
SyntaxError: expected ':'
```